### PR TITLE
docs: add processor resources (closes #619]

### DIFF
--- a/ProgrammingArticles.md
+++ b/ProgrammingArticles.md
@@ -18,6 +18,8 @@
 | [How Precision Time Protocol is being deployed at Meta](https://engineering.fb.com/2022/11/21/productin-engineering/precision-time-protocol-at-meta/) |
 | [PTP: Timing accuracy and precision for the future of computing](https://engineering.fb.com/2022/11/21/production-engineering/future-computing-ptp/) |
 
+## Technical Blogs
+
 | Technical Blogs |
 |----|
 | [Facebook Engineering Blog](https://engineering.fb.com/
@@ -26,6 +28,34 @@
 | [Microsoft Azure Dev Ops Blog](https://devblogs.microsoft.com/devops/) |
 | [NVIDIA Developer Blog](https://developer.nvidia.com/blog/) |
 
+## ARM
+
+| [Arm](https://www.arm.com/) |
+|----|
+| [Arm Products](https://www.arm.com/products) |
+| [Arm Solutions](https://www.arm.com/solutions) |
+| [Company Information](https://www.arm.com/company) |
+| [Product Support](https://www.arm.com/support) |
+| [Developer Resources](https://developer.arm.com/) |
+| [Community](https://community.arm.com/) |
+
+| ARM History |
+|----|
+| [A history of ARM, part 1: Building the first chip](https://arstechnica.com/gadgets/2022/09/a-history-of-arm-part-1-building-the-first-chip/)<br>In 1983, Acorn Computers needed a CPU. So 10 people built one. |
+| [A history of ARM, part 2: Everything starts to come together](https://arstechnica.com/gadgets/2022/11/a-history-of-arm-part-2-everything-starts-to-come-together/)<br>What had started as twelve people and a dream was now a billion-dollar company. |
+| [A history of ARM, part 3: Coming full circle](https://arstechnica.com/gadgets/2023/01/a-history-of-arm-part-3-coming-full-circle/) |
+
+## RISC-V
+
+| [RISC-V](https://riscv.org/) |
+|----|
+||
+
+## SPARC
+
+| [SPARC](https://sparc.org/) |
+|----|
+||
 
 [^1]: [Michael Shpilt](https://michaelscodingspot.com/about/)
 [^2]: Sorry Meta, but you will always be known as Facebook. 


### PR DESCRIPTION
| [Arm](https://www.arm.com/) |
|----|
| [Arm Products](https://www.arm.com/products) |
| [Arm Solutions](https://www.arm.com/solutions) | | [Company Information](https://www.arm.com/company) | | [Product Support](https://www.arm.com/support) | | [Developer Resources](https://developer.arm.com/) | | [Community](https://community.arm.com/) |

| ARM History |
|----|
| [A history of ARM, part 1: Building the first chip](https://arstechnica.com/gadgets/2022/09/a-history-of-arm-part-1-building-the-first-chip/)<br>In 1983, Acorn Computers needed a CPU. So 10 people built one. | | [A history of ARM, part 2: Everything starts to come together](https://arstechnica.com/gadgets/2022/11/a-history-of-arm-part-2-everything-starts-to-come-together/)<br>What had started as twelve people and a dream was now a billion-dollar company. | | [A history of ARM, part 3: Coming full circle](https://arstechnica.com/gadgets/2023/01/a-history-of-arm-part-3-coming-full-circle/) | | [RISC-V](https://riscv.org/) |
|----|
| []() |

| [SPARC](https://sparc.org/) |