### PR TITLE
fix: updated copyright year

### DIFF
--- a/Apache2_0LICENSE.md
+++ b/Apache2_0LICENSE.md
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 202y Ralph M. Hightower, Jr.
+   Copyright 2023 Ralph M. Hightower, Jr.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
- there's no code in RalphHightower/RalphHightower, but I updated the for future use. License in effect is in LICENSE.md.