### PR TITLE
[docs](doc): HardwareLinks(extended description)

### DIFF
--- a/HardwareLinks.md
+++ b/HardwareLinks.md
@@ -122,7 +122,7 @@
 | [iwavesystems SBC](https://www.iwavesystems.com/form-factor/sbc-cots/ ) | (H/W) |
 | [iwavesystems AM62Ax Based OSM-LF Module](https://www.iwavesystems.com/product/ti-am62ax-based-osm-lf-module/# )
 | [Jameco](https://www.jameco.com/c/Fans-Cooling.html) | (H/W) |
-| [Kendryte K230 RISC-V Development Board – CanMV-K230 – AnalogLamb](https://www.analoglamb.com/product/kendryte-k230-risc-v-development-board-canmv-k230/ ) | $49.99 |
+| [Kendryte K230 RISC-V Development Board – CanMV-K230 – AnalogLamb](https://www.analoglamb.com/product/kendryte-k230-risc-v-development-board-canmv-k230/ ) | (H/W) $49.99 |
 | **[Khadas 5G NR Module](https://www.khadas.com/product-page/5g-nr-module)** | (H/W) $239.90 |
 | [Khadas \(ARM Single Board Computers\)](https://www.khadas.com/shop?Collection=All) | (H/W) |
 | [Khadas / VIM4 w/ NPU, Active Cooling](https://www.khadas.com/product-page/vim4 ) | (H/W) $$239.90 w/ NPU, Active Cooling|
@@ -565,6 +565,10 @@
 | [Youyeetoo YY3568 devkit review - Part 1: Unboxing, specifications, and Android 11 testing - CNX Software](https://www.cnx-software.com/2023/08/25/youyeetoo-yy3568-devkit-review-part-1-unboxing-specifications-and-android-11-testing/ ) |
 | [CanMV-K230 AI development board features Kendryte K230 dual-core 64-bit RISC-V processor - CNX Software](https://www.cnx-software.com/2023/10/24/canmv-k230-ai-development-board-features-kendryte-k230-dual-core-64-bit-risc-v-processor/ ) |
 | [SV6301A Handheld Vector Network Analyzer Teardown Pictures – Kerry D. Wong](http://www.kerrywong.com/2023/10/15/sv6301a-handheld-vector-network-analyzer-teardown-pictures/ ) |
+| [Embedded System on Modules (SOMs) Design & Development](https://www.dusuniot.com/landing-pages/som-developer/ ) |
+| [DSOM-020R PX30 development board review - Unboxing, Benchmarks, and Zigbee gateway - CNX Software](https://www.cnx-software.com/2023/10/24/dsom-020r-px30-development-board-review-unboxing-benchmarks-and-zigbee-gateway/ ) |
+| [CanMV-K230 AI development board features Kendryte K230 dual-core 64-bit RISC-V processor - CNX Software](https://www.cnx-software.com/2023/10/24/canmv-k230-ai-development-board-features-kendryte-k230-dual-core-64-bit-risc-v-processor/ ) |
+| [RISC-V Bases and Extensions Explained - CNX Software](https://www.cnx-software.com/2019/08/27/risc-v-bases-and-extensions-explained/ ) |
 
 [^21]: • 1.5GHz quad-core 64-bit ARM Cortex-A72 CPU (Roughly 3× performance)<br />• 1GB, 2GB, or 4GB of LPDDR4 SDRAM<br />• Full-throughput Gigabit Ethernet<br />• Dual-band 802.11ac wireless networking<br />• Bluetooth 5.0<br />• Two USB 3.0 and two USB 2.0 ports<br />• Dual monitor support, at resolutions up to 4K<br />• VideoCore VI graphics, supporting OpenGL ES 3.x<br />• 4Kp60 hardware decode of HEVC video<br />Complete compatibility with earlier Raspberry Pi products
 


### PR DESCRIPTION
- HardwareLinks 
  - Vendors
    - | [Kendryte K230 RISC-V Development Board – CanMV-K230 – AnalogLamb](https://www.analoglamb.com/product/kendryte-k230-risc-v-development-board-canmv-k230/ ) | $49.99 |
  - Articles 
    - | [Embedded System on Modules (SOMs) Design & Development](https://www.dusuniot.com/landing-pages/som-developer/ ) |
    - | [DSOM-020R PX30 development board review - Unboxing, Benchmarks, and Zigbee gateway - CNX Software](https://www.cnx-software.com/2023/10/24/dsom-020r-px30-development-board-review-unboxing-benchmarks-and-zigbee-gateway/ ) |
    - | [CanMV-K230 AI development board features Kendryte K230 dual-core 64-bit RISC-V processor - CNX Software](https://www.cnx-software.com/2023/10/24/canmv-k230-ai-development-board-features-kendryte-k230-dual-core-64-bit-risc-v-processor/ ) |
    - | [RISC-V Bases and Extensions Explained - CNX Software](https://www.cnx-software.com/2019/08/27/risc-v-bases-and-extensions-explained/ ) |
