### PR TITLE
[feat](doc): NewsSpace(extended description)

### DIFF
--- a/News/NewsSpace.md
+++ b/News/NewsSpace.md
@@ -3,3 +3,171 @@
 | Space News |
 |---|
 | [If Betelgeuse Goes Supernova, Earth Will Have Neutrino Rain — That's Just the Start](https://www.inverse.com/science/betelgeuse-supernova-effects ) |
+| [How NASA’s first six women astronauts changed space - The Verge](https://www.theverge.com/23869799/sally-ride-nichelle-nichols-six-women-astronauts-nasa-space-spacex ) |
+| [Interstellar Travel: Magnetic Fusion Plasma Engines Could Carry Us Across the Solar System and Beyond](https://scitechdaily.com/interstellar-travel-magnetic-fusion-plasma-engines-could-carry-us-across-the-solar-system-and-beyond/ ) |
+| [After the sting of Ariane 6, Europe finally embraces commercial rockets / Ars Technica](https://arstechnica.com/space/2023/11/after-the-sting-of-ariane-6-europe-finally-embraces-commercial-rockets/ ) |
+| [Astronomers want JWST to study the Milky Way core for hundreds of hours](https://phys.org/news/2023-10-astronomers-jwst-milky-core-hundreds.html ) |
+| [Euclid 'dark universe' telescope captures 1st full-color views of the cosmos (images) / Space](https://www.space.com/dark-matter-euclid-mission-first-breathtaking-images ) |
+| [New research shows quasars can be buried in their host galaxies](https://phys.org/news/2023-11-quasars-host-galaxies.html ) |
+| [Supermassive black hole found only half a billion years after Big Bang / Ars Technica](https://arstechnica.com/science/2023/11/half-of-the-mass-of-an-early-galaxy-is-in-its-central-black-hole/ ) |
+| [The most distant spacecraft in the solar system — Where are they now? / Space](https://www.space.com/most-distant-spacecraft-voyagers-new-horizons ) |
+| [NASA Shows Off Experimental ‘Next-Generation’ Advanced Electric Propulsion System - The Debrief](https://thedebrief.org/nasa-shows-off-experimental-next-generation-advanced-electric-propulsion-system/ ) |
+| [A supermassive black hole's strong magnetic fields are revealed in a new light](https://phys.org/news/2023-11-supermassive-black-hole-strong-magnetic.html ) |
+| [After the sting of Ariane 6, Europe finally embraces commercial rockets / Ars Technica](https://arstechnica.com/space/2023/11/after-the-sting-of-ariane-6-europe-finally-embraces-commercial-rockets/ ) |
+| [Artemis moon astronauts will need oxygen. NASA wants to extract it from lunar dust / Space](https://www.space.com/nasa-oxygen-from-moon-dust ) |
+| [Astronomers want JWST to study the Milky Way core for hundreds of hours](https://phys.org/news/2023-10-astronomers-jwst-milky-core-hundreds.html ) |
+| [Do gravitational waves exhibit wave-particle duality? - Big Think](https://bigthink.com/starts-with-a-bang/gravitational-waves-wave-particle-duality/ ) |
+| [Euclid 'dark universe' telescope captures 1st full-color views of the cosmos (images) / Space](https://www.space.com/dark-matter-euclid-mission-first-breathtaking-images ) |
+| [Evidence of alien life may exist in the fractures of icy moons around Jupiter and Saturn / Space](https://www.space.com/icy-moon-ganymede-titan-jupiter-saturn-signs-life ) |
+| [James Webb Space Telescope gets ready for the holidays with a cosmic Christmas Tree (image) / Space](https://www.space.com/james-webb-space-telescope-christmas-tree-galaxy-cluster ) |
+| [James Webb Space Telescope reveals distances of nearly 200 deep-space galaxies / Space](https://www.space.com/james-webb-space-telescope-200-galaxies-distances-revealed ) |
+| [James Webb Space Telescope reveals most distant Milky Way galaxy doppelganger / Space](https://www.space.com/james-webb-space-telescope-milky-way-look-alike ) |
+| [If the next Starship makes it through staging, you can call that a win / Ars Technica](https://arstechnica.com/space/2023/11/if-the-next-starship-makes-it-through-staging-you-can-call-that-a-win/ ) |
+| [Inside the Star Factory](https://mitpress.mit.edu/9780262047906/inside-the-star-factory/ ) |
+| [NASA Envisions Uranus Flagship Class Mission](https://www.forbes.com/sites/alisonwinfield-burns/2023/11/03/nasa-envisions-uranus-flagship-class-mission/ ) |
+| [NASA Shows Off Experimental ‘Next-Generation’ Advanced Electric Propulsion System - The Debrief](https://thedebrief.org/nasa-shows-off-experimental-next-generation-advanced-electric-propulsion-system/ ) |
+| [NASA's exoplanet hunting telescope spies 8 'super-Earths' / Space](https://www.space.com/nasa-tess-exoplanet-telescope-8-super-earths ) |
+| [New research shows quasars can be buried in their host galaxies](https://phys.org/news/2023-11-quasars-host-galaxies.html ) |
+| [One step closer to unveiling dark matter with ARRAKIHS](https://phys.org/news/2023-11-closer-unveiling-dark-arrakihs.html ) |
+| [Photographer Spends 15 Years Capturing the Construction of the James Webb Space Telescope / PetaPixel](https://petapixel.com/2023/11/09/photographer-spends-15-years-capturing-the-construction-of-the-james-webb-space-telescope/ ) |
+| [Physicists Simulated a Black Hole in The Lab, And Then It Started to Glow : ScienceAlert](https://www.sciencealert.com/physicists-simulated-a-black-hole-in-the-lab-and-then-it-started-to-glow-2 ) |
+| [Squeezing the Universe: LIGO Breaks the Quantum Limit](https://scitechdaily.com/squeezing-the-universe-ligo-breaks-the-quantum-limit/ ) |
+| [Stronger solar activity could bring more displays of the northern lights in 2024 : NPR](https://www.npr.org/2023/11/09/1211595597/northern-lights-aurora-borealis-2024 ) |
+| [Supermassive black hole found only half a billion years after Big Bang / Ars Technica](https://arstechnica.com/science/2023/11/half-of-the-mass-of-an-early-galaxy-is-in-its-central-black-hole/ ) |
+| [Supermassive black holes shut down star formation during cosmic noon, says astronomer](https://phys.org/news/2023-11-supermassive-black-holes-star-formation.html ) |
+| [The most distant spacecraft in the solar system — Where are they now? / Space](https://www.space.com/most-distant-spacecraft-voyagers-new-horizons ) |
+| [The oldest continents in the Milky Way may be 5 billion years older than Earth's / Live Science](https://www.livescience.com/space/exoplanets/the-oldest-continents-in-the-milky-way-may-be-5-billion-years-older-than-earths ) |
+| [What is STEVE, and how is it different from the aurora? / Space](https://www.space.com/what-is-steve ) |
+| [You've got to see Webb telescope's eerie view of the Crab Nebula / Mashable](https://mashable.com/article/james-webb-space-telescope-crab-nebula ) |
+| [Dark matter may have its own 'invisible' periodic table of elements / Live Science](https://www.livescience.com/space/cosmology/dark-matter-may-have-its-own-invisible-periodic-table-of-elements ) |
+| [Eroding remains of over 100 star-stripped '"missing link'" dwarf galaxies spotted / Live Science](https://www.livescience.com/space/astronomy/tiny-galaxies-that-had-their-stars-stolen-could-be-a-missing-link-in-cosmic-evolution ) |
+| [NASA is breaking a cardinal rule of branding](https://www.fastcompany.com/90979557/nasa-is-breaking-a-cardinal-rule-of-branding ) |
+| [NASA snapped a breathtaking view of deep space / Mashable](https://mashable.com/article/nasa-james-webb-space-telescope-galaxies ) |
+| [NASA’s Juno Spacecraft Discovers Jupiter’s Winds Penetrate the Planet in Cylindrical Layers](https://scitechdaily.com/nasas-juno-spacecraft-discovers-jupiters-winds-penetrate-the-planet-in-cylindrical-layers/ ) |
+| [Star-birthing galaxies can hide supermassive black holes behind walls of dust / Space](https://www.space.com/supermassive-black-hole-galaxies-dust-walls-hide ) |
+| [US military gives Lockheed Martin $33.7 million to develop nuclear spacecraft / Space](https://www.space.com/space-nuclear-power-tech-lockheed-martin-jetson-contract ) |
+| [The four fundamental liforces of nature / Live Science](https://www.livescience.com/the-fundamental-forces-of-nature.html ) |
+| [James Webb Space Telescope could soon solve mysteries of the Milky Way's heart / Space](https://www.space.com/james-webb-space-telescope-milky-way-heart-mystery ) |
+| **[How Black Holes Consume Entropy - Universe Today](https://www.universetoday.com/164150/how-black-holes-consume-entropy/ )** |
+| ['Bouncing' comets may be able to spread life throughout the universe / Space](https://www.space.com/comets-bouncing-seed-life-on-exoplanets ) |
+| ['Peculiar' aurora-like radio signal from sunspot discovered for the 1st time / Space](https://www.space.com/sunspot-emissions-similar-to-auroras-earth ) |
+| [57 years ago, two astronauts saw the first solar eclipse from space](https://www.astronomy.com/space-exploration/57-years-ago-first-solar-eclipse-from-space/ ) |
+| **[A successful liftoff: Space shuttle Endeavour's rockets are installed](https://phys.org/news/2023-11-successful-liftoff-space-shuttle-endeavour.html )** |
+| [An Amateur Astronomer Discovered One-of-a-Kind Supernova Remnant - Universe Today](https://www.universetoday.com/164136/an-amateur-astronomer-discovered-one-of-a-kind-supernova-remnant/ ) |
+| [Answering longstanding questions about jets from black holes](https://phys.org/news/2023-11-longstanding-jets-black-holes.html ) |
+| [Big bang: Dutch firm eyes space baby](https://phys.org/news/2023-11-big-dutch-firm-eyes-space.html ) |
+| [Can technology save astronomy from light pollution? - Big Think](https://bigthink.com/starts-with-a-bang/technology-save-astronomy-light-pollution/ ) |
+| [Cosmic Chameleon: Galaxy’s Stunning Transformation by Hubble Filters](https://scitechdaily.com/cosmic-chameleon-galaxys-stunning-transformation-by-hubble-filters/ ) |
+| [Cosmic Fossils Unearthed: Euclid Unravels the Ancient NGC 6397 Cluster](https://scitechdaily.com/cosmic-fossils-unearthed-euclid-unravels-the-ancient-ngc-6397-cluster/ ) |
+| [Daily Telescope: An amazing, colorful view of the Universe / Ars Technica](https://arstechnica.com/space/2023/11/daily-telescope-an-amazing-colorful-view-of-the-universe/ ) |
+| [Daily Telescope: Two galaxies colliding 300 million light-years from Earth – Ars Technica](https://arstechnica.com/space/2023/11/daily-telescope-a-celestial-flowering-as-two-galaxies-collide/ ) |
+| [Dedicated Amateur Astronomer Makes Rare Pair of Asteroid Discoveries - Universe Today](https://www.universetoday.com/163983/amateur-astronomer-makes-pair-of-asteroid-discoveries/ ) |
+| [Earth has many objects in orbit but definitely only one Moon / Space](https://theconversation.com/earth-has-many-objects-in-orbit-but-definitely-only-one-moon-despite-what-some-people-think-217209 ) |
+| [Earth’s Surface Is Leaking Water Down To Its Core / IFLScience](https://www.iflscience.com/earths-surface-is-leaking-water-down-to-its-core-71570 ) |
+| [Einstein must be wrong: How general relativity fails to explain the universe / Live Science](https://theconversation.com/why-einstein-must-be-wrong-in-search-of-the-theory-of-gravity-211067 ) |
+| [EXCLUSIVE: The 'Impossible' Quantum Drive That Defies Known Laws of Physics was Just Launched into Space - The Debrief](https://thedebrief.org/exclusive-the-impossible-quantum-drive-that-defies-known-laws-of-physics-was-just-launched-into-space/ ) |
+| [First U.S. Commercial Small Nuclear Reactor Axed - IEEE Spectrum](https://spectrum.ieee.org/small-modular-reactors-nuscale ) |
+| [Gaia is so accurate it can predict microlensing events](https://phys.org/news/2023-11-gaia-accurate-microlensing-events.html ) |
+| [Ghost Particle Unmasked: Project 8’s Neutrino Mass Breakthrough](https://scitechdaily.com/ghost-particle-unmasked-project-8s-neutrino-mass-breakthrough/ ) |
+| [Galactic Collision Captured in Stunning Detail: NASA’s Webb & Hubble Unite To Create Most Colorful View of Universe](https://scitechdaily.com/galactic-collision-captured-in-stunning-detail-nasas-webb-hubble-unite-to-create-most-colorful-view-of-universe/ ) |
+| [How to think about a four-dimensional universe](https://phys.org/news/2023-11-four-dimensional-universe.html ) |
+| [Hubble Telescope investigates nearby exoplanet, finds it's Earth-size / Space](https://www.space.com/hubble-telescope-earth-size-exoplanet-transit ) |
+| [If you account for the Laniakea supercluster, the Hubble tension might be even larger](https://phys.org/news/2023-11-account-laniakea-supercluster-hubble-tension.html ) |
+| [High-energy cosmic rays may originate within the Milky Way galaxy / Space](https://www.space.com/iss-cosmic-ray-detector-energetic-particles-milky-way ) |
+| [How U.S. satellite rules are different only for Israel : NPR](https://www.npr.org/2023/11/16/1212889717/satellite-images-us-israel-gaza ) |
+| [How did time begin, and how will it end? - BBC Future](https://www.bbc.com/future/article/20231115-how-did-time-begin-and-how-will-it-end ) |
+| [Is sex in space being taken seriously by the emerging space tourism sector?](https://phys.org/news/2023-04-sex-space-emerging-tourism-sector.html ) |
+| [Is the vacuum of space truly empty? / Space](https://www.space.com/is-the-vacuum-of-space-truly-empty ) |
+| [Is time travel even possible? An astrophysicist explains the science behind the science fiction](https://theconversation.com/is-time-travel-even-possible-an-astrophysicist-explains-the-science-behind-the-science-fiction-213836 ) |
+| [James Webb Space Telescope Spots Strangely Familiar Looking Celestial Object That May Upend Theories of Galactic Formation - The Debrief](https://thedebrief.org/james-webb-space-telescope-spots-strangely-familiar-looking-celestial-object-that-may-upend-theories-of-galactic-formation/ ) |
+| [James Webb Space Telescope finds 2 of the most distant galaxies ever seen / Space](https://www.space.com/james-webb-space-telescope-distant-galaxies ) |
+| [James Webb Space Telescope reveals sandy surprise in distant exoplanet / Space](https://www.space.com/james-webb-space-telescope-exoplanet-sand-clouds-atmosphere ) |
+| [Milky Way's hidden supernova revealed by JWST - Big Think](https://bigthink.com/starts-with-a-bang/hidden-supernova-jwst/ ) |
+| [NASA Built a 'Tire Assault Vehicle' From an RC Tank to Explode Space Shuttle Tires](https://www.thedrive.com/news/nasa-built-a-tire-assault-vehicle-from-an-rc-tank-to-explode-space-shuttle-tires ) |
+| [NASA Funding Development of “Game-Changing” Rotating Detonation Rocket Engines - The Debrief](https://thedebrief.org/nasa-funding-development-of-game-changing-rotating-detonation-rocket-engines/ ) |
+| [NASA Telescope Reveals Clues to Elusive 'Size Gap' in Planets](https://gizmodo.com/retired-nasa-telescope-reveals-clues-to-the-elusive-siz-1851029005 ) |
+| [NASA's Mars robots are on their own right now — here's why / Space](https://www.space.com/nasa-mars-rovers-orbiters-solar-conjunction-2023 ) |
+| [NASA's SPHEREx mission aims to map 450 million galaxies and 100 million stars / Space](https://www.space.com/nasa-spherex-map-450-million-galaxies ) |
+| [Phosphorous discovered in outskirts of the Milky Way for the first time](https://phys.org/news/2023-11-phosphorous-outskirts-milky.html ) |
+| [Physicists Uncover a New State of Matter Hidden in The Quantum World : ScienceAlert](https://www.sciencealert.com/physicists-uncover-a-new-state-of-matter-hidden-in-the-quantum-world ) |
+| [Scientists Just Recreated The Chemical Reaction That May Have Led to Life on Earth : ScienceAlert](https://www.sciencealert.com/scientists-just-recreated-the-chemical-reaction-that-may-have-led-to-life-on-earth ) |
+| [See the sun's savage surface like never before in new timelapse video / Space](https://www.space.com/sun-timelapse-solar-activity-dark-sky-view ) |
+| [Sex in space: Why it's worrying that the space tourism sector hasn't considered the consequences](https://phys.org/news/2023-07-sex-space-tourism-sector-hasnt.html ) |
+| [Solar eclipses seen by long-dead Cassini spacecraft shed new light on Saturn's rings / Space](https://www.space.com/saturn-rings-transparency-cassini-eclipse-data ) |
+| [Space Force eyes a future of speed and agility in orbit - SpaceNews](https://spacenews.com/space-force-eyes-a-future-of-speed-and-agility-in-orbit/ ) |
+| [The Best Timed Shot in TV History (Probably)](https://greekreporter.com/2023/11/09/best-timed-shot-tv-history/ ) |
+| [The origins of the black hole information paradox](https://phys.org/news/2023-11-black-hole-paradox.html ) |
+| [Why are things in spacenews.com that causes such things round? / Live Science](https://www.livescience.com/space/why-are-things-in-space-round ) |
+| [Ultracold atoms in space will let us stress test Einstein's relativity / New Scientist](https://www.newscientist.com/article/2402740-ultracold-atoms-in-space-will-let-us-stress-test-einsteins-relativity/ ) |
+[Unlocking Fundamental Mysteries: Using Near-Miss Particle Physics to Peer Into Quantum World](https://scitechdaily.com/unlocking-fundamental-mysteries-using-near-miss-particle-physics-to-peer-into-quantum-world/)|[We Finally Know the True Power of the Brightest Gamma-Ray Burst](https://gizmodo.com/power-brightness-gamma-ray-burst-boat-1851025152 ) |
+| [When Stars Consume Their Partners, We Could Detect a Blast of Neutrinos - Universe Today](https://www.universetoday.com/164228/when-stars-consume-their-partners-we-could-detect-a-blast-of-neutrinos/ ) |
+| [Why Even Einstein Couldn't Unite Physics - Universe Today](https://www.universetoday.com/164144/why-even-einstein-couldnt-unite-physics/ ) |
+| ['First Ever' Experiments to Measure Theoretical 'Quantum Flickering' in an Empty Vacuum Slated for 2024 - The Debrief](https://thedebrief.org/first-ever-experiments-to-measure-theoretical-quantum-flickering-in-an-empty-vacuum-slated-for-2024/ ) |
+| [‘First light’: NASA receives laser-beamed message from 10 million miles away – AccuWeather.com/en/](https://www.accuweather.com/en/space-news/first-light-nasa-receives-laser-beamed-message-from-10-million-miles-away/1598462 ) |
+| ['The Making of JUICE' film shows how scientists built a Jupiter-bound spacecraft / Space](https://www.space.com/europe-juice-jupiter-icy-moons-mission-documentary ) |
+| [1st black hole ever imaged is losing energy through 'lightsaber' jets / Space](https://www.space.com/supermassive-black-hole-m87-losing-energy ) |
+| [A Century Later, New Math Smooths Out General Relativity / Quanta Magazine](https://www.quantamagazine.org/a-century-later-new-math-smooths-out-general-relativity-20231130/ ) |
+| [Aerocapture is a Free Lunch in Space Exploration - Universe Today](https://www.universetoday.com/164482/aerocapture-is-a-free-lunch-in-space-exploration/ ) |
+| [Amateur Astrophotographer Discovers New “Phantom Stinger” In Scorpio Constellation’s Tail / IFLScience](https://www.iflscience.com/amateur-astrophotographer-discovers-new-phantom-stinger-in-scorpio-constellations-tail-71725 ) |
+| [As the ISS turns 25, a look back at the space laboratory's legacy / Space](https://www.space.com/iss-25-anniversary-achievements-legacy-nasa ) |
+| [Astronomers discover the Milky Way's faintest satellite](https://phys.org/news/2023-11-astronomers-milky-faintest-satellite.html ) |
+| [Astronomers find dozens of massive stars fleeing the Milky Way](https://phys.org/news/2023-11-astronomers-dozens-massive-stars-milky.html ) |
+| [Brightest gamma-ray explosion of all time scrambled Earth's upper atmosphere / Live Science](https://www.livescience.com/space/black-holes/brightest-gamma-ray-explosion-of-all-time-scrambled-earths-upper-atmosphere ) |
+| [Could This—Finally—Be Humanity's First Permanent Lunar Base?](https://gizmodo.com/thales-alenia-space-first-lunar-base-moon-asi-1851052777 ) |
+| [Dark Matter Could Help Solve the Final Parsec Problem of Black Holes - Universe Today](https://www.universetoday.com/164452/dark-matter-could-help-solve-the-final-parsec-problem-of-black-holes/ ) |
+| [Dark Matter Might Be Recycled To Form A Whole Invisible Periodic Table / IFLScience](https://www.iflscience.com/dark-matter-might-be-recycled-to-form-a-whole-invisible-periodic-table-71555 ) |
+| [Dark matter may be hiding in the Large Hadron Collider's particle jets / Space](https://www.space.com/large-hadron-collider-dark-matter-particle-jets ) |
+| [Dark Matter Could Help Solve the Final Parsec Problem of Black Holes - Universe Today](https://www.universetoday.com/164452/dark-matter-could-help-solve-the-final-parsec-problem-of-black-holes/ ) |
+| [Dark Matter Might Be Recycled To Form A Whole Invisible Periodic Table / IFLScience](https://www.iflscience.com/dark-matter-might-be-recycled-to-form-a-whole-invisible-periodic-table-71555 ) |
+| [Dark matter may be hiding in the Large Hadron Collider's particle jets / Space](https://www.space.com/large-hadron-collider-dark-matter-particle-jets ) |
+| [Data from Fermi Gamma-ray Space Telescope reveal gamma radiation pulses from Sagittarius A*](https://phys.org/news/2023-11-fermi-gamma-ray-space-telescope-reveal.html ) |
+| [Data from NASA’s Webb Telescope backs up ideas on planet formation – Ars Technica](https://arstechnica.com/science/2023/11/data-from-nasas-webb-telescope-backs-up-ideas-on-planet-formation/ ) |
+| [Data from Fermi Gamma-ray Space Telescope reveal gamma radiation pulses from Sagittarius A*](https://phys.org/news/2023-11-fermi-gamma-ray-space-telescope-reveal.html ) |
+| [Data from NASA’s Webb Telescope backs up ideas on planet formation – Ars Technica](https://arstechnica.com/science/2023/11/data-from-nasas-webb-telescope-backs-up-ideas-on-planet-formation/ ) |
+| [Dwarf galaxies use 10-million-year quiet period to churn out stars](https://phys.org/news/2023-11-dwarf-galaxies-million-year-quiet-period.html ) |
+| [For Henry Kissinger, NASA'S Apollo 11 lunar landing was about more than the moon / Space](https://www.space.com/henry-kissinger-apollo-program-moon-landing ) |
+| [For its Next Trick, Gaia Could Help Detect Background Gravitational Waves in the Universe - Universe Today](https://www.universetoday.com/164498/for-its-next-trick-gaia-could-help-detect-background-gravitational-waves-in-the-universe/ ) |
+| [Generating Power on Earth From the Coldness of Deep Space - IEEE Spectrum](https://spectrum.ieee.org/energy-from-cold ) |
+| [How NASA Keeps Ingenuity Going After More than 50 Flights - Universe Today](https://www.universetoday.com/164438/how-nasa-keeps-ingenuity-going-after-more-than-50-flights/ ) |
+| [Is Earth's Magnetic Field on The Verge of Flipping Over? An Expert Explains. : ScienceAlert](https://www.sciencealert.com/is-earths-magnetic-field-on-the-verge-of-flipping-over-an-expert-explains ) |
+| [‘I’ve dedicated my life to this mission’: Sara Sabry on making space exploration more accessible / CNN](https://www.cnn.com/world/sara-sabry-space-exploration-scn-spc/index.html ) |
+| [Ivy League astronaut shares top NASA wisdom for problem solving](https://www.cnbc.com/2023/11/27/ivy-league-astronaut-shares-top-nasa-wisdom-for-problem-solving.html ) |
+| [JWST Reveals Protoplanetary Disks in a Nearby Star Cluster - Universe Today](https://www.universetoday.com/164470/jwst-reveals-protoplanetary-disks-in-a-nearby-star-cluster/ ) |
+| [JWST now owns the top 8 spots for most distant objects - Big Think](https://bigthink.com/starts-with-a-bang/jwst-top-8-most-distant-objects/ ) |
+| [James Webb Space Telescope finds water and methane in atmosphere of a 'warm Jupiter' / Space](https://www.space.com/james-webb-space-telescope-wasp-80-b-methane-water-vapor ) |
+| [James Webb Space Telescope spies a newborn star in its cosmic crib (image) / Space](https://www.space.com/james-webb-space-telescope-herbig-haro-object-nov-2023 ) |
+| [James Webb telescope discovers 'Cosmic Vine' of 20 connected galaxies sprawling through the early universe / Live Science](https://www.livescience.com/space/astronomy/james-webb-telescope-discovers-cosmic-vine-of-20-connected-galaxies-sprawling-through-the-early-universe ) |
+| [James Webb telescope reveals 'nursery' of 500,000 stars in the chaotic heart of the Milky Way / Live Science](https://www.livescience.com/space/astronomy/james-webb-telescope-reveals-nursery-of-500000-stars-in-the-chaotic-heart-of-the-milky-way ) |
+| [James Webb telescope reveals gargantuan 'Mothra' star in most colorful image of the universe ever taken / Live Science](https://www.livescience.com/space/astronomy/james-webb-telescope-reveals-gargantuan-mothra-star-in-most-colorful-image-of-the-universe-ever-taken ) |
+| [Key Ingredient For Life Discovered in The Last Place Astronomers Expected : ScienceAlert](https://www.sciencealert.com/key-ingredient-for-life-discovered-in-the-last-place-astronomers-expected ) |
+| [Mystery Solved: We Finally Know Why The Milky Way Seems So Unique : ScienceAlert](https://www.businessinsider.com/astronomers-may-know-why-milky-way-galaxy-rare-2023-11 ) |
+| [NASA postpones Dragonfly review, launch date - SpaceNews](https://spacenews.com/nasa-postpones-dragonfly-review-launch-date/ ) |
+| [New Study Lists The Ways a Rogue Star Could Spell Doom For Our Solar System : ScienceAlert](https://www.sciencealert.com/new-study-lists-the-ways-a-rogue-star-could-spell-doom-for-our-solar-system ) |
+| [New astrophysics model sheds light on additional source of long gamma-ray bursts](https://phys.org/news/2023-11-astrophysics-additional-source-gamma-ray.html ) |
+| [New constraints on the presence of ultralight dark matter in the Milky Way](https://phys.org/news/2023-11-constraints-presence-ultralight-dark-milky.html ) |
+| [Over the past six years, governments proposed launching over one million satellites, but where will they all go? / Space](https://theconversation.com/over-the-past-six-years-governments-proposed-launching-over-one-million-satellites-but-where-will-they-all-go-215979 ) |
+| [Physicists find evidence of exotic charge transport in quantum material](https://phys.org/news/2023-11-physicists-evidence-exotic-quantum-material.html ) |
+| [Researchers show an old law still holds for quirky quantum materials](https://phys.org/news/2023-11-law-quirky-quantum-materials.html ) |
+| [Sagittarius A*, our galaxy’s black hole, spins fast and drags space-time with it / CNN](https://www.cnn.com/2023/11/28/world/sagittarius-a-black-hole-spin-space-time-scn/index.html ) |
+| [Scientists chart the stories of young stars — from being born to moving out / Space](https://www.space.com/adolescent-star-evolution-galactic-stellar-clusters ) |
+| [Scientists detect a cosmic ray that’s almost as powerful as the ‘Oh-My-God’ particle / CNN](https://www.cnn.com/2023/11/23/americas/powerful-cosmic-ray-amaterasu-particle-detected-scn/index.html ) |
+| [Scientists found a planet-forming disk beyond our Milky Way for 1st time / Space](https://www.space.com/planet-forming-disk-young-star-1st-outside-milky-way-galaxy ) |
+| [Scientists rule out a popular alternative theory to dark matter - Big Think](https://bigthink.com/hard-science/dark-matter-alternative-modified-newtonian-dynamics-ruled-out/ ) |
+| [Starquakes Might Solve the Mysteries of Stellar Magnetism / WIRED](https://www.wired.com/story/starquakes-might-solve-the-mysteries-of-stellar-magnetism/ ) |
+| [Strange Explosion Captured in a Nearby Galaxy Wasn't a One-Off : ScienceAlert](https://www.sciencealert.com/strange-explosion-captured-in-a-nearby-galaxy-wasnt-a-one-off ) |
+| [Steve: The aurora-like light show you can help research / CNN](https://www.cnn.com/2023/11/28/world/steve-aurora-lights-scn/index.html ) |
+| [The Early Universe Had No Problem Making Barred Spiral Galaxies - Universe Today](https://www.universetoday.com/164463/the-early-universe-had-no-problem-making-barred-spiral-galaxies/ ) |
+| [The Fast and the Luminous: First Visible Wavelength Femtosecond Fiber Laser Developed](https://scitechdaily.com/the-fast-and-the-luminous-first-visible-wavelength-femtosecond-fiber-laser-developed/ ) |
+| [The echoes from inflation could still be shaking the cosmos today](https://phys.org/news/2023-11-echoes-inflation-cosmos-today.html ) |
+| [The Mars helicopter Ingenuity is an amazing success. NASA's already testing tech for the next generation (video) / Space](https://www.space.com/mars-rotor-system-test-nears-supersonic-speeds-ingenuity-flies-coincides ) |
+| [Theoretical work indicates that the future Electron Ion Collider can be used to measure the shape of atomic nuclei](https://phys.org/news/2023-11-theoretical-future-electron-ion-collider.html ) |
+| [There Aren't Many Galaxies Like The Milky Way Nearby. Now We Know Why - Universe Today](https://www.universetoday.com/164414/there-arent-many-galaxies-like-the-milky-way-nearby-now-we-know-why/#google_vignette ) |
+| [Titan Dragonfly is Go!.... for Phase C - Universe Today](https://www.universetoday.com/164532/titan-dragonfly-is-go-for-phase-c/ ) |
+| [Ultra-compact particle accelerator does a mile's work with four inches](https://newatlas.com/physics/wakefield-accelerator-tau/ ) |
+| [Using gravitational wave observations of a binary black hole merger to verify the no-hair theorem](https://phys.org/news/2023-11-gravitational-binary-black-hole-merger.html ) |
+| [Watch "The making of Juice: the film" on YouTube](https://youtu.be/TOKyzXulb-Y? ) |
+| [Webb telescope reveals new details in Milky Way’s heart / CNN](https://www.cnn.com/2023/11/20/world/webb-telescope-milky-way-heart-scn/index.html ) |
+| [What was it like at the beginning of the Big Bang? - Big Think](https://bigthink.com/starts-with-a-bang/beginning-big-bang/ ) |
+| [Where are All the Double Planets? - Universe Today](https://www.universetoday.com/164456/where-are-all-the-double-planets/ ) |
+| [Wild New Study Suggests We Could Use Tiny Black Holes as Sources of Nuclear Power : ScienceAlert](https://www.sciencealert.com/wild-new-study-suggests-we-could-use-tiny-black-holes-as-sources-of-nuclear-power ) |
+| [Zhurong rover detects mysterious polygons beneath the surface of Mars](https://phys.org/news/2023-11-zhurong-rover-mysterious-polygons-beneath.html ) |


### PR DESCRIPTION
- moved from NASA_SpaceNews (NASA_SpaceNews will be renamed NASA)