### PR TITLE
[docs](web): CanonMirrorlessRF(extended description)

### DIFF
--- a/Photography/CanonMirrorlessRF.md
+++ b/Photography/CanonMirrorlessRF.md
@@ -13,6 +13,11 @@
 | [Canon EOS R6 Mk II Review](https://www.thephoblographer.com/2023/02/03/canon-eos-r6-mk-ii-review/ ) |
 | [Canon EOS R7 vs Canon EOS R5 vs Canon EOS R](https://www.thephoblographer.com/2022/07/21/canon-eos-r7-vs-canon-eos-r5-vs-canon-eos-r-how-do-they-compare/ ) |
 | [Canon Patent Application: Full Frame Quad Pixel AF Sensor](https://www.canonrumors.com/canon-patent-application-full-frame-quad-pixel-sensor/ ) |
+| [Canon EOS R5: Full Mirrorless Camera Review](https://www.learnphotographyskills.com/canon-eos-r5-full-review/ ) |
+| [Hate Post-Production? The Canon EOS R5 Has a Great Feature](https://www.thephoblographer.com/2023/11/29/hate-post-production-the-canon-eos-r5-has-a-great-new-feature/ ) |
+| [Camera: Canon EOS R6 Mark II (Photography Museum) – Springer Photo Graphics](https://springerphotographics.com/2023/03/06/camera-canon-eos-r6-mark-ii-photography-museum/ ) |
+| [Canon EOS R6 MK II Review - DustinAbbott\.net](https://dustinabbott.net/2023/04/canon-eos-r6-mk-ii-review/ ) |
+| [Using the Canon R6 Mark II: My initial thoughts](https://blog.jeffcable.com/2023/04/using-canon-r6-mark-ii-my-initial.html ) |
 
 ## Canon RF Lenses
 
@@ -24,6 +29,9 @@
 | [Big Results. Small Price Tag. Canon RF 15-30mm F4.5-6.3 Review](https://www.thephoblographer.com/2023/01/20/big-results-small-price-tag-canon-rf-15-30mm-f4-5-6-3-review/ ) |
 | [The RF 24-105mm f/2.8L IS USM Z won't be the last RF PowerZoom lens](https://www.canonrumors.com/the-rf-24-105mm-f-2-8l-is-usm-z-wont-be-the-last-rf-powerzoom-lens/ ) |
 | [Do Canon's old EF lenses limit new EOS R mirrorless cameras? / Digital Camera World](https://www.digitalcameraworld.com/tutorials/do-canons-old-ef-lenses-limit-new-mirrorless-eos-r-series-cameras ) |
+| [The Best Lenses for Canon's RF Mount / PetaPixel](https://petapixel.com/best-canon-rf-lenses/ ) |
+| [The State of RF - 5 Years of Lenses](https://www.canonrumors.com/the-state-of-the-rf-lenses-5-years-in/ ) |
+| [Hypnotic Photos, Gigantic Lens: Canon RF 800mm F5.6 L Review](https://www.thephoblographer.com/2022/08/11/canon-rf-800mm-f5-6-review/ ) |
 
 | Canon RF Lens — [The Best Lenses for Canon's RF Mount / PetaPixel](https://petapixel.com/best-canon-rf-lenses/ )[^11] |
 |----|
@@ -76,4 +84,10 @@
 | [Hypnotic Photos, Gigantic Lens: Canon RF 800mm F5.6 L Review](https://www.thephoblographer.com/2022/08/11/canon-rf-800mm-f5-6-review/ ) |
 
 [^21]: [The Phoblographer](https://www.thephoblographer.com/)
+
+## Printers
+
+| Canon Printers |
+|---|
+| [Printing big and BIGGER with my Canon printers!](https://blog.jeffcable.com/2023/06/printing-big-and-bigger-with-my-canon.html ) |
 


### PR DESCRIPTION
- Photography 
   - CanonMirrorlessRF
      - Cameras 
         - | [Canon EOS R5: Full Mirrorless Camera Review](https://www.learnphotographyskills.com/canon-eos-r5-full-review/ ) |
         - | [Hate Post-Production? The Canon EOS R5 Has a Great Feature](https://www.thephoblographer.com/2023/11/29/hate-post-production-the-canon-eos-r5-has-a-great-new-feature/ ) |
         - | [Camera: Canon EOS R6 Mark II (Photography Museum) – Springer Photo Graphics](https://springerphotographics.com/2023/03/06/camera-canon-eos-r6-mark-ii-photography-museum/ ) |
         - | [Canon EOS R6 MK II Review - DustinAbbott\.net](https://dustinabbott.net/2023/04/canon-eos-r6-mk-ii-review/ ) |
         - | [Using the Canon R6 Mark II: My initial thoughts](https://blog.jeffcable.com/2023/04/using-canon-r6-mark-ii-my-initial.html ) |
      - Lenses
         - | [The Best Lenses for Canon's RF Mount / PetaPixel](https://petapixel.com/best-canon-rf-lenses/ ) |
         - | [The State of RF - 5 Years of Lenses](https://www.canonrumors.com/the-state-of-the-rf-lenses-5-years-in/ ) |
         - | [Hypnotic Photos, Gigantic Lens: Canon RF 800mm F5.6 L Review](https://www.thephoblographer.com/2022/08/11/canon-rf-800mm-f5-6-review/ ) |
      - Printers
         - | [Printing big and BIGGER with my Canon printers!](https://blog.jeffcable.com/2023/06/printing-big-and-bigger-with-my-canon.html ) |