### PR TITLE
[docs](web): NewsComputers(extended description)

### DIFF
--- a/News/NewsComputers.md
+++ b/News/NewsComputers.md
@@ -4,3 +4,10 @@
 |---|
 | [Quantum computers could overtake classical ones within 2 years, IBM 'benchmark' experiment shows / Space](https://www.livescience.com/technology/computing/quantum-computers-could-overtake-classical-ones-within-2-years-ibm-benchmark-experiment-shows ) |
 | [Microsoft says its weird new particle could improve quantum computers / New Scientist](https://www.newscientist.com/article/2378782-microsoft-says-its-weird-new-particle-could-improve-quantum-computers/ ) |
+| [How one national lab is getting its supercomputers ready for the AI age / FedScoop](https://fedscoop.com/how-one-national-lab-is-getting-its-supercomputers-ready-for-the-ai-age/ ) |
+| [OpenAI's Chaos Linked to Super Powerful New AI It Secretly Built](https://futurism.com/openais-chaos-powerful-new-ai ) |
+| ['Off to the races': DARPA, Harvard breakthrough brings quantum computing years closer - Breaking Defense](https://breakingdefense.com/2023/12/off-to-the-races-darpa-harvard-breakthrough-brings-quantum-computing-years-closer/ ) |
+| [Researchers improve magnets for computing](https://phys.org/news/2023-11-magnets.html ) |
+| [A universal framework describing the scrambling of quantum information in open systems](https://phys.org/news/2023-11-universal-framework-scrambling-quantum.html ) |
+| [Photonic chip that 'fits together like Lego' opens door to semiconductor industry](https://phys.org/news/2023-12-photonic-chip-lego-door-semiconductor.html ) |
+| [Physicists 'entangle' individual molecules for the first time, hastening possibilities for quantum computing](https://phys.org/news/2023-12-physicists-entangle-individual-molecules-hastening.html ) |


### PR DESCRIPTION
- News
   - NewsComputing
      - | [How one national lab is getting its supercomputers ready for the AI age / FedScoop](https://fedscoop.com/how-one-national-lab-is-getting-its-supercomputers-ready-for-the-ai-age/ ) |
      - | [OpenAI's Chaos Linked to Super Powerful New AI It Secretly Built](https://futurism.com/openais-chaos-powerful-new-ai ) |
      - | ['Off to the races': DARPA, Harvard breakthrough brings quantum computing years closer - Breaking Defense](https://breakingdefense.com/2023/12/off-to-the-races-darpa-harvard-breakthrough-brings-quantum-computing-years-closer/ ) |
      - | [Researchers improve magnets for computing](https://phys.org/news/2023-11-magnets.html ) |
      - | [A universal framework describing the scrambling of quantum information in open systems](https://phys.org/news/2023-11-universal-framework-scrambling-quantum.html ) |
      - | [Photonic chip that 'fits together like Lego' opens door to semiconductor industry](https://phys.org/news/2023-12-photonic-chip-lego-door-semiconductor.html ) |
      - | [Physicists 'entangle' individual molecules for the first time, hastening possibilities for quantum computing](https://phys.org/news/2023-12-physicists-entangle-individual-molecules-hastening.html ) |
