### PR TITLE
[docs](web): Update SolarEclipse(footnote of drop-in filters)

### DIFF
--- a/Photography/SolarEclipse.md
+++ b/Photography/SolarEclipse.md
@@ -107,20 +107,20 @@
 | [Canon EOS R5 Mirrorless Camera](https://www.lensrentals.com/rent/canon-eos-r5)[^42] | $175.00 for 7 days | Rent[^42] |  [LensRentals Cordova, KY](https://www.lensrentals.com/) |
 | **Lens** |
 | [Canon EF 100-400mm f/4.5-5.6L IS II](https://www.lensrentals.com/rent/canon-100-400mm-f4.5-5.6l-is-ii )[^43] 77mm O.D.  94mm | $101.00 / 7 days | Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) | 
-| [Canon EF 200-400mm f/4L IS with 1.4x Extender](https://www.lensrentals.com/rent/canon-200-400mm-f4l-is-with-1.4x-extender )[^43] 52mm drop-in O.D. 128mm | $419.00 / 7 days | Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon EF 300mm f/2.8L IS II](https://www.lensrentals.com/rent/canon-300mm-f2.8l-is-ii )[^43] 52mm drop-in O.D. 128mm | $271.00 / 7 days| Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon EF 400mm f/4 DO IS II](https://www.lensrentals.com/rent/canon-400mm-f4-do-is-ii )[^43] 52mm drop-in O.D. 128mm | $239.00 / 7 days| Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon EF 400mm f/2.8L IS III](https://www.lensrentals.com/rent/canon-400mm-f2.8l-is-iii )[^43] 52mm drop-in O.D. 163mm  | $458.00 / 7 days| Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon EF 500mm f/4L IS II](https://www.lensrentals.com/rent/canon-500mm-f4l-is-ii )[^43] 52mm drop-in O.D. 146mm | $405.00 / 7 days| Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon EF 600mm f/4L IS III](https://www.lensrentals.com/rent/canon-600mm-f4l-is-iii )[^43] 52mm drop-in O.D. 168mm | $471.00 / 7 days| Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon EF 800mm f/5.6L IS](https://www.lensrentals.com/rent/canon-800mm-f5.6l-is )[^43] 52mm drop-in O.D. 168mm | $425.00 / 7 days| Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon EF 200-400mm f/4L IS with 1.4x Extender](https://www.lensrentals.com/rent/canon-200-400mm-f4l-is-with-1.4x-extender )[^43] 52mm drop-in[^54] O.D. 128mm | $419.00 / 7 days | Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon EF 300mm f/2.8L IS II](https://www.lensrentals.com/rent/canon-300mm-f2.8l-is-ii )[^43] 52mm drop-in[^54] O.D. 128mm | $271.00 / 7 days| Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon EF 400mm f/4 DO IS II](https://www.lensrentals.com/rent/canon-400mm-f4-do-is-ii )[^43] 52mm drop-in[^54] O.D. 128mm | $239.00 / 7 days| Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon EF 400mm f/2.8L IS III](https://www.lensrentals.com/rent/canon-400mm-f2.8l-is-iii )[^43] 52mm drop-in[^54] O.D. 163mm  | $458.00 / 7 days| Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon EF 500mm f/4L IS II](https://www.lensrentals.com/rent/canon-500mm-f4l-is-ii )[^43] 52mm drop-in[^54] O.D. 146mm | $405.00 / 7 days| Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon EF 600mm f/4L IS III](https://www.lensrentals.com/rent/canon-600mm-f4l-is-iii )[^43] 52mm drop-in[^54] O.D. 168mm | $471.00 / 7 days| Rent[^43] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon EF 800mm f/5.6L IS](https://www.lensrentals.com/rent/canon-800mm-f5.6l-is )[^43] 52mm drop-in[^54] O.D. 168mm | $425.00 / 7 days| Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
 | [Canon RF 100-300mm f/2.8 L IS USM Lens](https://www.bhphotovideo.com/c/product/1762615-REG/canon_rf_100_300mm_f_2_8_l.html ) 112mm O.D. 128mm | — | — | — |
 | [Canon RF 100-500mm f/4.5-7.1L IS USM](https://www.lensrentals.com/rent/canon-rf-100-500mm-f4.5-7.1l-is-usm )[^44] 77mm O.D. 93.8mm | $93.00 / 7 days | Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
 | [Canon RF 200-800mm f/6.3-9 IS USM](https://www.lensrentals.com/rent/canon-rf-200-800mm-f6.3-9-is-usm )[^44] 95mm O.D. 102.3mm | $83.00 / 7 days | Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon RF 400mm f/2.8L IS USM](https://www.lensrentals.com/rent/canon-rf-400mm-f2.8l-is-usm )[^44] 52mm drop-in O.D. 163mm | $440.00 / 7 days  | Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon RF 600mm f/4L IS USM](https://www.lensrentals.com/rent/canon-rf-600mm-f4l-is-usm )[^44] 52mm drop-in O.D. 168mm | $471.00 / 7 days | Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon RF 800mm f/5.6L IS USM](https://www.lensrentals.com/rent/canon-rf-800mm-f5.6l-is-usm )[^44] 52mm drop-in O.D. 163mm | $675.00 / 7 day s| Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
-| [Canon RF 1200mm f/8L IS USM](https://www.lensrentals.com/rent/canon-rf-1200mm-f8l-is-usm )[^44] 52mm drop-in O.D. 168mm | $791.00 / 7 days,| Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon RF 400mm f/2.8L IS USM](https://www.lensrentals.com/rent/canon-rf-400mm-f2.8l-is-usm )[^44] 52mm drop-in[^54] O.D. 163mm | $440.00 / 7 days  | Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon RF 600mm f/4L IS USM](https://www.lensrentals.com/rent/canon-rf-600mm-f4l-is-usm )[^44] 52mm drop-in[^54] O.D. 168mm | $471.00 / 7 days | Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon RF 800mm f/5.6L IS USM](https://www.lensrentals.com/rent/canon-rf-800mm-f5.6l-is-usm )[^44] 52mm drop-in[^54] O.D. 163mm | $675.00 / 7 day s| Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
+| [Canon RF 1200mm f/8L IS USM](https://www.lensrentals.com/rent/canon-rf-1200mm-f8l-is-usm )[^44] 52mm drop-in[^54] O.D. 168mm | $791.00 / 7 days,| Rent[^44] | [LensRentals Cordova, KY](https://www.lensrentals.com/) |
 | **Solar Filter** |
 | [DayStar Filters 90mm White-Light Universal Lens Solar ULF90-2](https://www.bhphotovideo.com/c/product/1319794-REG/daystar_filters_ulf90_2_universal_lens_filter_for.html ) | $39.95 | Own | [B&H, NYC, NY](https://www.bhphotovideo.com/) |
 | [DayStar Filters Camera Quark H-Alpha Solar Filter DSZTCP B&H](https://www.bhphotovideo.com/c/product/1302634-REG/daystar_filters_dsztcp_camera_quark_eyepiece_filter.html )[^45] | $1,495.00 | Buy[^45] | [B&H, NYC, NY](https://www.bhphotovideo.com/) |
@@ -171,3 +171,4 @@
 [^51]: If Celestron Advanced VX GoTo German Equatorial Mount is chosen, purchase these items also.
 [^52]: If iOptron SkyGuider Pro EQ Camera Mount is chosen, select these items also.
 [^53]: Choose just one software controller.
+[^54]: Canon super telephoto lenses that have drop-in filters do not have front filter threads. Use the outside diameter (O.D.) to determine the diameter for the slip-on filter.


### PR DESCRIPTION
- Canon super telephoto lenses with drop-in filters do not have front filter threads.