### PR TITLE
[docs](web): Update PublixGasCard(extended description)

### DIFF
--- a/Shopping/PublixGasCard.md
+++ b/Shopping/PublixGasCard.md
@@ -8,5 +8,9 @@
 | 2024-02-14 | 2024-02-18 | 28 |
 | 2024-01-17 | 2024-01-21 |  |
 
+To keep track of the remaining balance on the gas card, I use a Post-It™ tag to write the remaining balance on the tag.
+
+Using the $50 gas cards provides a layer of security from credit card skimmers hidden in gas pumps because the potential loss is limited to less than $50.
+
 [^11]: Lexington, and Richland Counties, South Carolina. \$10 off \$50 gas card for \$50 groceries purchase, excluding lottery tickets, phone cards, beer, wine.<br />[Using a debit card, multiple cards may be purchased, one for each $50 purchase with the same exclusions.]
 [^12]: I am using this page to determine a frequency pattern to this great sale. – *Ralph Hightower*


### PR DESCRIPTION
- Shopping
   - PublixGasCard
      - To keep track of the remaining balance on the gas card, I use a Post-It™ tag to write the remaining balance on the tag.
      - Using the $50 gas cards provides a layer of security from credit card skimmers hidden in gas pumps because the potential loss is limited to less than $50.