### PR TITLE
[docs](web): Comics/[CalvinAndHobbes m|FarSide],Media/òNCIS|RebootedTVShows]

### DIFF
--- a/Comics/CalvinAndHobbes.md
+++ b/Comics/CalvinAndHobbes.md
@@ -6,6 +6,8 @@
 
 | [Calvin and Hobbes / CBR](https://www.cbr.com/tag/calvin-and-hobbes/ ) | CBR Published Date |
 |---|---|
+| [Did a Fake Calvin and Hobbes Comic Strip Sell For Over $14,000?](https://www.cbr.com/fake-calvin-and-hobbes-comic-strip-sell-14000/ ) | May 7, 2024 |
+| [Calvin & Hobbes: 10 Best Philosophies from the Comic Strip](https://www.cbr.com/best-calvin-hobbes-philosophies/ ) | May 7, 2024 |
 | [10 Best Calvin & Hobbes Comic Strips for Parents](https://www.cbr.com/best-calvin-hobbes-for-parents/ ) | May 2, 2024 |
 | [10 Best Calvin & Hobbes Quotes](https://www.cbr.com/best-calvin-hobbes-quotes/ ) | Apr 29, 2024 |
 | [9 Weirdest Details From Early Calvin And Hobbes Comics](https://www.cbr.com/calvin-and-hobbes-weirdest-details-early-comic-strips/ ) | Apr 23, 2024 |

--- a/Comics/FarSide.md
+++ b/Comics/FarSide.md
@@ -16,6 +16,8 @@
 
 | [Gary Larson: The Far Side / ScreenRant](https://screenrant.com/tag/the-far-side/ ) | Published Date  |
 |---|--- |
+| [Far Side Creator Gary Larson's Dream Gig Reveals Why Experimentation Was Instrumental to the Comic (Hint: It Wasn't Cartoonist)](https://screenrant.com/far-side-gary-larson-dream-job-jazz-guitarist/ ) | May 8, 2024 |
+| [15 Funniest Far Side Comics That Prove It's Obsessed with Miniature People](https://screenrant.com/funniest-far-side-comics-gary-larson-miniature-people/ ) | May 7, 2024 |
 | [Some Of Gary Larson's Best Far Side Comics Had Mind-Blowing Backstories](https://screenrant.com/far-side-comics-backstories-gary-larson/ ) | May 4, 2024 |
 | [Far Side's Funniest Fourth Wall-Breaking Comic Perfectly Explains Its Recurring Characters](https://screenrant.com/far-side-funniest-comics-recurring-characters-gary-larson/ ) | May 2, 2024 |
 | [10 Funniest Far Side Comics That Just Turned 40](https://screenrant.com/funniest-far-side-comics-gary-larson-april-1984/ ) | Apr 30, 2024 |
@@ -128,6 +130,7 @@
 
 | [Comics Lists • FarSide / CBR](https://www.cbr.com/category/comics-lists/ )[^21] | Date |
 |---|---|
+| [The Far Side's Confusing Jokes Even Became a Gag on the Sitcom Cheers](https://www.cbr.com/far-side-confusing-jokes-cheers-gag/ ) | May 8, 2024 |
 | [10 Best Historical The Far Side Comics, Ranked](https://www.cbr.com/best-historical-far-side-comics/ ) | APR 10, 2024 |
 | [10 Funniest The Far Side Comics About Animals, Ranked](https://www.cbr.com/best-far-side-comics-funny-animals-ranked/ ) | APR 5, 2024 |
 | [Gary Larson's 10 Most Underrated The Far Side Comics](https://www.cbr.com/the-far-side-underrated-forgotten-comics/ ) | MAR 26, 2024 |

--- a/Media/NCIS.md
+++ b/Media/NCIS.md
@@ -19,6 +19,7 @@
 
 | NCIS News | Date |
 |---|---|
+| [NCIS Spinoff Reuniting Cote de Pablo and Michael Weatherly Gets Its Title](https://www.cbr.com/ncis-michael-weatherly-cote-de-pablo-spinoff/ ) | May 7, 2024 |
 | ['NCIS' Cote de Pablo, Michael Weatherly Spinoff Set at Paramount+](https://variety.com/2024/tv/news/ncis-spinoff-cote-de-pablo-michael-weatherly-paramount-plus-1235925895/ ) |
 | [NCIS Season 21 Ducky Tribute Secretly Set Up Tony And Ziva’s Spinoff](https://screenrant.com/ncis-season-21-ducky-tribute-dinozzo-ziva-spinoff-setup/ ) |
 | [Michael Weatherly and Cote de Pablo’s Tony and Ziva ‘NCIS’ spinoff is ordered at Paramount+ / March 2024 📺 - Training Hearts Academy](https://trainingheartsacademy.com/michael-weatherly-and-cote-de-pablos-tony-and-ziva-ncis-spinoff-is-ordered-at-paramount-march-2024/ ) |

--- a/Media/RebootedTVShows.md
+++ b/Media/RebootedTVShows.md
@@ -41,7 +41,7 @@
 | NCIS: New Orleans | NCIS | CBS |
 | NCIS: Sydney| NCIS | CBS |
 | NCIS – Origins[^31]<sup>,</sup>[^32] | NCIS | Paramount+ |
-| NCIS – Europe[^33]<sup>,</sup>[^34]<sup>,</sup>[^35]<sup>,</sup>[^36]  | NCIS | Paramount+ |
+| NCIS – Tony and Ziva[^33]<sup>,</sup>[^34]<sup>,</sup>[^35]<sup>,</sup>[^36] | NCIS | Paramount+ |
 | Star Trek: Next Generation | Star Trek | CBS |
 | Star Trek: Deep Space Nine | Star Trek | CBS |
 | Star Trek: Voyager | Star Trek | CBS |
@@ -63,6 +63,7 @@
 [^34]: ['NCIS' Cote de Pablo, Michael Weatherly Spinoff Set at Paramount+](https://variety.com/2024/tv/news/ncis-spinoff-cote-de-pablo-michael-weatherly-paramount-plus-1235925895/ )| Star Trek: Next Generation | Star Trek | CBS |
 [^35]: ["Dinozzo Is Coming": Michael Weatherly Teases New NCIS Location For Tony & Ziva Spinoff](https://screenrant.com/ncis-tony-dinozzo-ziva-spinoff-michael-weatherly-location-photo/ )
 [^36]: [Inside Michael Weatherly and Cote de Pablo's adorable friendship ahead of NCIS: Europe / HELLO!](https://www.hellomagazine.com/film/515590/ncis-stars-michael-weatherly-and-cote-de-pablo-sweet-friendship-explored/ )
+[^37]: [NCIS Spinoff Reuniting Cote de Pablo and Michael Weatherly Gets Its Title](https://www.cbr.com/ncis-michael-weatherly-cote-de-pablo-spinoff/ ) | May 7, 2024
 
 ## Shows That Deserve Rebooting
 


### PR DESCRIPTION
- Comics
   - CalvinAndHobbes 
      - CBR
         - | [Did a Fake Calvin and Hobbes Comic Strip Sell For Over $14,000?](https://www.cbr.com/fake-calvin-and-hobbes-comic-strip-sell-14000/ ) | May 7, 2024 |
         - | [Calvin & Hobbes: 10 Best Philosophies from the Comic Strip](https://www.cbr.com/best-calvin-hobbes-philosophies/ ) | May 7, 2024 |
   - FarSide 
      - | [Did a Fake Calvin and Hobbes Comic Strip Sell For Over $14,000?](https://www.cbr.com/fake-calvin-and-hobbes-comic-strip-sell-14000/ ) | May 7, 2024 |
      - | [Calvin & Hobbes: 10 Best Philosophies from the Comic Strip](https://www.cbr.com/best-calvin-hobbes-philosophies/ ) | May 7, 2024 |
   - CBR
      - | [The Far Side's Confusing Jokes Even Became a Gag on the Sitcom Cheers](https://www.cbr.com/far-side-confusing-jokes-cheers-gag/ ) | May 8, 2024 |
- Media
   - NCIS
      - Replace(| NCIS – Europe[^33]<sup>,</sup>[^34]<sup>,</sup>[^35]<sup>,</sup>[^36]  | NCIS | Paramount+ |)
      - With(| NCIS – Tony and Ziva[^33]<sup>,</sup>[^34]<sup>,</sup>[^35]<sup>,</sup>[^36] | NCIS | Paramount+ |)
   - RebootedTVShows
      - Replace(| NCIS – Europe[^33]<sup>,</sup>[^34]<sup>,</sup>[^35]<sup>,</sup>[^36]  | NCIS | Paramount+ |)
      - With(| NCIS – Tony and Ziva[^33]<sup>,</sup>[^34]<sup>,</sup>[^35]<sup>,</sup>[^36] | NCIS | Paramount+ |)

[^37]: [NCIS Spinoff Reuniting Cote de Pablo and Michael Weatherly Gets Its Title](https://www.cbr.com/ncis-michael-weatherly-cote-de-pablo-spinoff/ ) | May 7, 2024
