### PR TITLE
[docs](web): Comics/[CalvinAndHobbes|FarSide]/ScreenRant-added strips

### DIFF
--- a/Comics/CalvinAndHobbes.md
+++ b/Comics/CalvinAndHobbes.md
@@ -1,6 +1,7 @@
 # Comics \| Calvin And Hobbes 
 
 | Best Calvin And Hobbes Collections | Price |
+
 |---|---|
 | **[The Complete Calvin and Hobbes \[Box Set\]: Bill Watterson, Bill Watterson: 8601420153295: Amazon.com: Books](https://www.amazon.com/Complete-Calvin-Hobbes-Box-Set/dp/0740748475?tag=gamespot-bfcm-20 )** | **$99.58** |
 
@@ -108,6 +109,7 @@
 
 | [Calvin and Hobbes / ScreenRant](https://screenrant.com/tag/calvin-and-hobbes/ ) | ScreenRant Published |
 |---|---|
+| [This Calvin & Hobbes Comic Would NEVER Be Published Today](https://screenrant.com/calvin-hobbes-inappropriate-comic/ ) | May 12, 2024 |
 | [Calvin & Hobbes Combines with DC's Shazam in Adorable Bill Watterson Tribute](https://screenrant.com/calvin-hobbes-tribute-shazam-comic/ ) | Apr 29, 2024 |
 | [Indiana Jones Meets Calvin & Hobbes in Genius Recreation of Bill Watterson's Art Style](https://screenrant.com/indiana-jones-calvin-hobbes-fanart-bill-wattersons-art-style/ ) | APR 11, 2024 |
 | [Calvin & Hobbes' Very First Comic Reveals the Hilarious Way They Met](https://screenrant.com/calvin-and-hobbes-first-comic-reveals-how-they-met/ ) | Mar 25, 2024 |

--- a/Comics/FarSide.md
+++ b/Comics/FarSide.md
@@ -16,6 +16,7 @@
 
 | [Gary Larson: The Far Side / ScreenRant](https://screenrant.com/tag/the-far-side/ ) | Published Date  |
 |---|--- |
+| [The Far Side's First 10 Comics Are Still Hilarious Today](https://screenrant.com/funniest-far-side-comics-gary-larson-first-comics/ ) | May 12, 2024 |
 | [Gary Larson Told Fans Exactly How The Far Side Would End – A Decade Before It Did](https://screenrant.com/why-gary-larson-stopped-drawing-far-side-comics/ ) | May 10, 2024 |
 | [Far Side Creator Gary Larson's Dream Gig Reveals Why Experimentation Was Instrumental to the Comic (Hint: It Wasn't Cartoonist)](https://screenrant.com/far-side-gary-larson-dream-job-jazz-guitarist/ ) | May 8, 2024 |
 | [15 Funniest Far Side Comics That Prove It's Obsessed with Miniature People](https://screenrant.com/funniest-far-side-comics-gary-larson-miniature-people/ ) | May 7, 2024 |


### PR DESCRIPTION
- Comics 
   - CalvinAndHobbes
      - ScreenRant
         - | [This Calvin & Hobbes Comic Would NEVER Be Published Today](https://screenrant.com/calvin-hobbes-inappropriate-comic/ ) | May 12, 2024 |
   - FarSide 
      - ScreenRant 
         - | [The Far Side's First 10 Comics Are Still Hilarious Today](https://screenrant.com/funniest-far-side-comics-gary-larson-first-comics/ ) | May 12, 2024 |
