### PR TITLE
[docs](web): Update Comics[CalvinAndHobbes | FarSide](more comics)

### DIFF
--- a/Comics/CalvinAndHobbes.md
+++ b/Comics/CalvinAndHobbes.md
@@ -1,4 +1,4 @@
-# Comics \| Calvin And Hobbes 
+# Comics/Calvin And Hobbes 
 
 ## Books
 
@@ -124,6 +124,7 @@
 
 | [Calvin and Hobbes / ScreenRant](https://screenrant.com/tag/calvin-and-hobbes/ ) | ScreenRant Published |
 |---|---|
+| [10 Funniest Calvin and Hobbes Comics That Just Turned 30 (Including 1 of Calvin's Biggest Disasters\)](https://screenrant.com/funniest-calvin-and-hobbes-comics-june-2024/) | June 29, 2024 |
 | [10 Funniest Calvin and Hobbes Comics That Just Turned 30 (Including 1 of Calvin's Biggest Disasters\)](https://screenrant.com/funniest-calvin-and-hobbes-comics-june-2024/) | June 28, 2024 |
 | [Charlie Brown and Calvin Finally Meet in Adorable Peanuts/Calvin and Hobbes Mash-Up](https://screenrant.com/charlie-brown-peanuts-meets-calvin-hobbes-fan-art/) | Jun 24, 2024 |
 | [Calvin and Hobbes Creator' Learned Two Vital Lessons From Peanuts' Charles Schulz](https://screenrant.com/calvin-and-hobbes-peanuts-charles-schulz-bill-watterson/) | June 22, 2024 |

--- a/Comics/FarSide.md
+++ b/Comics/FarSide.md
@@ -1,4 +1,4 @@
-# Comics \| Far Side
+# Comics/Far Side
 
 ## Books
 
@@ -18,6 +18,7 @@
 
 | [Gary Larson: The Far Side / ScreenRant](https://screenrant.com/tag/the-far-side/ ) | Published Date  |
 |---|---|
+| [12 Far Side Comics From 1981 That Make Readers Go "What The?"](https://screenrant.com/far-side-comics-1981-confusing/) | July 5, 2024 |
 | [10 Funniest Far Side Comics Where Gary Larson Made Pirates Hilarious](https://screenrant.com/funniest-far-side-comics-pirates-gary-larson/) | June 30, 2024 |
 | [12 Far Side Comics From 1980 That Make Readers Go "What-the?"](https://screenrant.com/10-far-side-comics-1980-what-the/) | June 27, 2024 |
 | [25 Funniest The Far Side Comics That Will Never Get Old](https://screenrant.com/funniest-far-side-comics-gary-larson/) | June 24, 2024 |


### PR DESCRIPTION
- Comics 
    - CalvinAndHobbes
        - ScreenRant
           - #4187
           - | [10 Funniest Calvin and Hobbes Comics That Just Turned 30 (Including 1 of Calvin's Biggest Disasters\)](https://screenrant.com/funniest-calvin-and-hobbes-comics-june-2024/) | June 29, 2024 |
        - FarSide
           - ScreenRant 
              - #4188 
              - | [12 Far Side Comics From 1981 That Make Readers Go "What The?"](https://screenrant.com/far-side-comics-1981-confusing/) | July 5, 2024 |