### PR TITLE
[docs](web): Update SiriusXM_Presets(Deep Tracks Channel  Moved to High Band)

### DIFF
--- a/Media/SiriusXM_Presets.md
+++ b/Media/SiriusXM_Presets.md
@@ -1,4 +1,6 @@
-# Media \| SiriusXM Presets
+# Media/SiriusXM
+
+## SiriusXM Presets
 
 | Channel | Name | Genre | Content | Contact |
 |---------|-------|------|-----|-----------|
@@ -7,8 +9,11 @@
 | 24 | [Radio Margaritaville](https://www.siriusxm.com/channels/radio-margaritaville?intcmp=CG_NA_www:channels_RadioMargaritaville) | Rock | to Margaritaville. Parrotheads, your ship has come in. From multi-platinum singer, songwriter and author Jimmy Buffett comes a radio paradise of great music, live broadcasts of Buffett's concerts and other unique programs. | RadioMargaritaville@siriusxm.com <br />866-557-2776 |
 | 25 | [Classic Rewind](https://www.siriusxm.com/channels/classic-rewind) | Rock | '70s/'80s Classic Rock — Hit the rewind button for classic rock from the cassette years. Boston, The Cars, Van Halen, Foreigner and more from the late '70s and '80s. | classicrewind@siriusxm.com |
 | 26 | [Classic Vinyl](https://www.siriusxm.com/channels/classic-vinyl?intcmp=CG_NA_www:channels_ClassicVinyl) | Rock | All the great Classic Rock of the '60s and '70s when music came on vinyl. The Rolling Stones, Led Zeppelin, The Who, The Doors and more. Drop the needle on Classic Vinyl! | classicvinyl@siriusxm.com |
+| ~~308~~[^11] | [Deep Tracks](https://www.siriusxm.com/channels/deep-tracks) | Rock | Album cuts, forgotten gems and lesser played songs from some of Classic Rock’s most influential artists and essential albums with rare demos and live tracks. | deeptracks@siriusxm.com<br />866-267-0444 |
 | 27 | [Deep Tracks](https://www.siriusxm.com/channels/deep-tracks) | Rock | Album cuts, forgotten gems and lesser played songs from some of Classic Rock’s most influential artists and essential albums with rare demos and live tracks. | deeptracks@siriusxm.com<br />866-267-0444 |
 | 28 | [The Spectrum](https://www.siriusxm.com/channels/the-spectrum) | Rock | The spectrum of rock from the past, present and future. Neil Young through Dave Matthews Band to Wilco and tomorrow's great artists. | thespectrum@siriusxm.com |
 | 31 | [Tom Petty Radio](https://www.siriusxm.com/channels/tom-petty-radio) | Rock | Music from Rock & Roll Hall of Fame inductee Tom Petty, including his acclaimed Buried Treasure radio show and exclusive tracks from Tom's personal archives. | tompettyradio@siriusxm.com |
 | 32 | [U2 X-Radio](https://www.siriusxm.com/channels/u2-x-radio) | Rock | This is U2. This is radio. This is U2 X-RADIO. Featuring the songs of a band from the Northside of Dublin. A complete immersion into the music of Bono, The Edge, Larry Mullen and Adam Clayton. The band’s history, idols, influences and current passions. Plus inspiration, conversation, culture, commentary and ideas. U2 X-Radio will introduce listeners to old friends and new stories; as well as artists, writers, thinkers and activists who are changing the world. All curated by U2. | |
 | 33 | [1st Wave](https://www.siriusxm.com/channels/1st-wave) | Rock | Hear the first wave of Alternative and New Wave from the late ‘70s through the ‘80s. From early U2 and the Police to Depeche Mode and R.E.M. and the Cure to Blondie and Talking Heads. | 1stwave@siriusxm.com<br />877-MY-1-WAVE |
+
+[^11]: According to Wikipedia, Deep Tracks moved from 27 to 308 on November 8, 2023.


### PR DESCRIPTION
- Media/
   - SiriusXM_Presets.md
      - #4186 
         - | ~~308~~[^11] | [Deep Tracks](https://www.siriusxm.com/channels/deep-tracks) | Rock | Album cuts, forgotten gems and lesser played songs from some of Classic Rock’s most influential artists and essential albums with rare demos and live tracks. | deeptracks@siriusxm.com<br />866-267-0444 |

[^11]: According to Wikipedia, Deep Tracks moved from 27 to 308 on November 8, 2023.
