### PR TITLE
[rollback](build): github-pages demands Jekyll 3.9.5!

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,13 +23,37 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.10.0)
+    faraday (2.10.1)
       faraday-net_http (>= 2.0, < 3.2)
       logger
-    faraday-net_http (3.1.0)
+    faraday-net_http (3.1.1)
       net-http
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
+    ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     forwardable-extended (2.6.0)
+    google-protobuf (4.27.3)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.27.3-aarch64-linux)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.27.3-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.27.3-x86-linux)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.27.3-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.27.3-x86_64-linux)
       bigdecimal
       rake (>= 13)
@@ -62,10 +86,6 @@ GEM
     jekyll-github-metadata (2.16.1)
       jekyll (>= 3.4, < 5.0)
       octokit (>= 4, < 7, != 4.4.0)
-    jekyll-google_analytics (0.1.0)
-      jekyll (>= 3)
-    jekyll-last-modified-at (1.3.2)
-      jekyll (>= 3.7, < 5.0)
     jekyll-mentions (1.6.0)
       html-pipeline (~> 2.3)
       jekyll (>= 3.7, < 5.0)
@@ -75,11 +95,6 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-tagging (1.1.0)
-      nuggets
-    jekyll-toc (0.19.0)
-      jekyll (>= 3.9)
-      nokogiri (~> 1.12)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.7.2)
@@ -101,16 +116,25 @@ GEM
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
-    nokogiri (1.16.6-x86_64-linux)
+    nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
-    nuggets (1.6.1)
-    octokit (4.25.1)
+    nokogiri (1.16.7-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
+      racc (~> 1.4)
+    octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.1.1)
-    racc (1.8.0)
+    public_suffix (6.0.1)
+    racc (1.8.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -119,7 +143,25 @@ GEM
       strscan
     rouge (4.3.0)
     safe_yaml (1.0.5)
+    sass-embedded (1.77.8-aarch64-linux-gnu)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-aarch64-linux-musl)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-arm-linux-gnueabihf)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-arm-linux-musleabihf)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-arm64-darwin)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86-linux-gnu)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86-linux-musl)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86_64-darwin)
+      google-protobuf (~> 4.26)
     sass-embedded (1.77.8-x86_64-linux-gnu)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86_64-linux-musl)
       google-protobuf (~> 4.26)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -134,24 +176,32 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  x86_64-linux
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
-  jekyll (~> 4.3, >= 4.3.3)
   jekyll-avatar (~> 0.8.0)
   jekyll-github-metadata (~> 2.16, >= 2.16.1)
-  jekyll-google_analytics (~> 0.1.0)
-  jekyll-last-modified-at (~> 1.3, >= 1.3.2)
   jekyll-mentions (~> 1.6)
   jekyll-seo-tag (~> 2.8)
   jekyll-sitemap (~> 1.4)
-  jekyll-tagging (~> 1.1)
-  jekyll-toc (~> 0.19.0)
   json (~> 2.7, >= 2.7.2)
-  kramdown-parser-gfm (~> 1.1)
   minima (~> 2.5, >= 2.5.1)
   rake (~> 13.2, >= 13.2.1)
   sass-embedded (~> 1.77, >= 1.77.8)
 
 BUNDLED WITH
-   2.4.19
+   2.5.17


### PR DESCRIPTION
**2024-08-08 @RalphHightower: SOL! Don't know when github-pages will support Jekyll 4.3.3. There's an issue dating back to 2019 for Jekyll 4.0.0.**