### PR TITLE
[feat](utils): awk utility programs

### DIFF
--- a/.Tools/Resequence/CharacterCount.awk
+++ b/.Tools/Resequence/CharacterCount.awk
@@ -1,0 +1,3 @@
+###### @RalphHightower 2024-08-12
+###### Counts characters in a line (excludes .md extension)
+{ printf("%d:%s\n", length($0), $0) }

--- a/.Tools/Resequence/dateBold.awk
+++ b/.Tools/Resequence/dateBold.awk
@@ -1,0 +1,32 @@
+###### @RalphHightower 2024-08-23
+###### shows those markdown lines in table rows where bold, or non-bold lines aren't paired.
+###### awk field separator is the pipe symbol '|'
+###### | Event | Date |
+###### |-------|-------|
+###### | **$2** | **$3** |
+######
+###### Output is record number and the string of that record. 
+######
+BEGIN {
+    FS = "|"
+    EVENT = 2
+    DATE = 3
+    EDITS =0
+}
+{
+    if (NF >= 4) {
+        evt = index($EVENT, "**")
+        dt = index($DATE, "**")
+        debug = evt + dt
+        debug = 0
+        if (debug > 0)
+            printf("%d:%d:%d:%s\n", NR, evt, dt, $0)
+        if ((((evt > 0) && (dt == 0)) || ((evt == 0) && (dt > 0)))) {
+            EDITS ++
+            printf("%d:%s\n", NR, $0)
+            }
+        }
+    }
+END {
+    printf("%d lines need formatting\n", EDITS)
+    }


### PR DESCRIPTION
| Program | Purpose |
|---|---|
| CharacterCount | Counts characters in the record. I usually feed it filenames with their directory. find . -name "*.md" -type f -print | awk -f CharacterCount.awk |
| dateBold.awk| Prints those records in GitHub markdown where the bold type in the first column doesn’t match the second column. |

| Example | Date |
|---|---|
| row 1 | date 1
| row 2 | **date 2** |
| **row 3** | date 3 |
| **row 4** | **date 4** |

```
dateBold.awk would display the following given the table above:
4: | row 2 | **date 2** |
5: | **row 3** | date 3 |
```